### PR TITLE
Avoid AVX-related crashes in FFmpeg by aligning buffer

### DIFF
--- a/src/spek-fft.h
+++ b/src/spek-fft.h
@@ -3,6 +3,8 @@
 #include <memory>
 #include <vector>
 
+#include "spek-platform.h"
+
 class FFTPlan;
 
 class FFT
@@ -17,8 +19,16 @@ class FFTPlan
 public:
     FFTPlan(int nbits) :
         input_size(1 << nbits), output_size((1 << (nbits - 1)) + 1),
-        input(input_size), output(output_size) {}
-    virtual ~FFTPlan() {}
+        output(output_size)
+    {
+        // FFmpeg uses various assembly optimizations which expect
+        // input data to be aligned by up to 32 bytes (e.g. AVX)
+        this->input = (float*) spek_platform_aligned_alloc(32, sizeof(float) * input_size);
+    }
+    virtual ~FFTPlan()
+    {
+        spek_platform_aligned_free(this->input);
+    }
 
     int get_input_size() const { return this->input_size; }
     int get_output_size() const { return this->output_size; }
@@ -30,11 +40,11 @@ public:
     virtual void execute() = 0;
 
 protected:
-    float *get_input() { return this->input.data(); }
+    float *get_input() { return this->input; }
 
 private:
     int input_size;
     int output_size;
-    std::vector<float> input;
+    float *input;
     std::vector<float> output;
 };

--- a/src/spek-platform.cc
+++ b/src/spek-platform.cc
@@ -1,4 +1,6 @@
+#include <new>
 #include <cstring>
+#include <cstdlib>
 
 #ifdef OS_OSX
 #include <ApplicationServices/ApplicationServices.h>
@@ -48,5 +50,28 @@ double spek_platform_font_scale()
     return 1.3;
 #else
     return 1.0;
+#endif
+}
+
+void *spek_platform_aligned_alloc(size_t alignment, size_t size)
+{
+    void *ptr;
+#ifdef OS_WIN
+    ptr = _aligned_malloc(size, alignment);
+    if (!ptr)
+        throw std::bad_alloc();
+#else
+    if (posix_memalign(&ptr, alignment, size) != 0)
+        throw std::bad_alloc();
+#endif
+    return ptr;
+}
+
+void spek_platform_aligned_free(void *mem)
+{
+#ifdef OS_WIN
+     _aligned_free(mem);
+#else
+    free(mem);
 #endif
 }

--- a/src/spek-platform.h
+++ b/src/spek-platform.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <wx/string.h>
+#include <cstddef>
 
 // Platform-specific initialisation code.
 void spek_platform_init();
@@ -14,3 +15,7 @@ bool spek_platform_can_change_language();
 
 // Fonts are smaller on OSX.
 double spek_platform_font_scale();
+
+// Allocating aligned memory is very dependent on platform or compiler.
+void *spek_platform_aligned_alloc(size_t alignment, size_t size);
+void spek_platform_aligned_free(void *mem);


### PR DESCRIPTION
aligned malloc code tested only on Linux but Windows solution should work too according to stackoverflow

Avoids the following crash (#120):
<pre>
Thread 6 "spek" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffe1ceb700 (LWP 25012)]
fft16_avx () at libavcodec/x86/fft.asm:321
321	    mova       m2, Z(2)
(gdb) bt
#0  0x0000000000bb26a0 in fft16_avx () at libavcodec/x86/fft.asm:321
#1  0x0000000000bb27f5 in fft32_avx () at libavcodec/x86/fft.asm:358
#2  0x0000000000bb3205 in ff_imdct_calc_sse () at libavcodec/x86/fft.asm:786
#3  0x0000000000bb3245 in ff_imdct_calc_sse () at libavcodec/x86/fft.asm:786
#4  0x0000000000bb3285 in ff_imdct_calc_sse () at libavcodec/x86/fft.asm:786
#5  0x0000000000bb32c5 in ff_imdct_calc_sse () at libavcodec/x86/fft.asm:786
#6  0x0000000000bb3685 in ff_imdct_calc_sse () at libavcodec/x86/fft.asm:787
#7  0x0000000000bb2ed7 in ff_fft_calc_avx () at libavcodec/x86/fft.asm:562
#8  0x000000000079e1a4 in rdft_calc_c (s=0x1c18ba0, data=0x1c1a4b0) at libavcodec/rdft.c:69
#9  0x000000000046aad8 in FFTPlanImpl::execute() (this=0x1c1a240) at spek-fft.cc:38
#10 0x000000000046b61e in worker_func(void*) (pp=0x1c23690) at spek-pipeline.cc:437
#11 0x00007ffff5214297 in start_thread () at /usr/lib/libpthread.so.0
#12 0x00007ffff4f551ef in clone () at /usr/lib/libc.so.6
</pre>