### PR TITLE
use floating point decoders for mp1, mp2, mp3

### DIFF
--- a/src/spek-audio.cc
+++ b/src/spek-audio.cc
@@ -111,7 +111,28 @@ std::unique_ptr<AudioFile> Audio::open(const std::string& file_name, int stream)
     if (!error) {
         avstream = format_context->streams[audio_stream];
         codec_context = avstream->codec;
-        codec = avcodec_find_decoder(codec_context->codec_id);
+
+        switch (codec_context->codec_id) {
+        case AV_CODEC_ID_MP1:
+            codec = avcodec_find_decoder_by_name("mp1float");
+            break;
+        case AV_CODEC_ID_MP2:
+            codec = avcodec_find_decoder_by_name("mp2float");
+            break;
+        case AV_CODEC_ID_MP3:
+            codec = avcodec_find_decoder_by_name("mp3float");
+            break;
+        case AV_CODEC_ID_MP3ADU:
+            codec = avcodec_find_decoder_by_name("mp3adufloat");
+            break;
+        case AV_CODEC_ID_MP3ON4:
+            codec = avcodec_find_decoder_by_name("mp3on4float");
+            break;
+        default:
+            codec = avcodec_find_decoder(codec_context->codec_id);
+            break;
+        }
+
         if (!codec) {
             error = AudioError::NO_DECODER;
         }


### PR DESCRIPTION
For some reason ffmpeg doesn't use the floating point decoders for mp1, mp2 and mp3 by default - this forces use of these.

Makes the spek not have all the "clipping" artifacts anymore - left with floating point decoders, right without:

http://i.imgur.com/DxnNBwM.jpg