### PR TITLE
Minor improvements

### DIFF
--- a/src/spek-preferences.cc
+++ b/src/spek-preferences.cc
@@ -25,7 +25,8 @@ void SpekPreferences::init()
             lang = info->Language;
         }
     }
-    this->locale->Init(lang);
+    if (!this->locale->Init(lang))
+        fprintf(stderr, "failed to set language\n");
     this->locale->AddCatalog(GETTEXT_PACKAGE);
 }
 

--- a/src/spek.cc
+++ b/src/spek.cc
@@ -1,3 +1,8 @@
+#define NDEBUG
+/* disable debug messages included in wxwidgets
+ * see docs.wxwidgets.org/trunk/group__group__funcmacro__debug.html
+ */
+
 #include <wx/cmdline.h>
 #include <wx/log.h>
 #include <wx/socket.h>


### PR DESCRIPTION
 * defined a macro that disables wxwidget debugging output
   In my case wxwidgets complaines that the environment variable
   SESSION_MANAGER is not set.
   see http://trac.wxwidgets.org/ticket/16024
 * added a check for a wxwidgets function call