### PR TITLE
configure.ac: detect AR tool with AM_PROG_AR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Makefile.in
 Makefile.in.in
 aclocal.m4
 autom4te.cache
+ar-lib
 compile
 config.*
 configure

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@ AM_INIT_AUTOMAKE([1.11.1 foreign no-dist-gzip dist-xz serial-tests])
 AM_SILENT_RULES([yes])
 
 AC_LANG([C++])
+AM_PROG_AR
 AC_PROG_CXX
 CXXFLAGS="$CXXFLAGS -std=gnu++11 -Wall -Wextra"
 AC_PROG_CXXCPP


### PR DESCRIPTION
Before the change configure refers to 'ar' tool. After the change it
refers to 'x86_64-pc-linux-gnu-ar'. This helps user to consistently pick
'ar' tool implementation.

Reported-by: Agostino Sarubbo
Bug: https://bugs.gentoo.org/754861