### PR TITLE
Implement `$XDG_CONFIG_HOME` on Unix systems

### DIFF
--- a/src/spek-platform.cc
+++ b/src/spek-platform.cc
@@ -24,8 +24,14 @@ wxString spek_platform_config_path(const wxString& app_name)
 #ifdef OS_WIN
     wxFileName file_name(wxStandardPaths::Get().GetUserConfigDir(), wxEmptyString);
 #else
-    wxFileName file_name(wxGetHomeDir(), wxEmptyString);
-    file_name.AppendDir(".config");
+    wxFileName file_name;
+    wxString xdg_config_home;
+    if (wxGetEnv("XDG_CONFIG_HOME", &xdg_config_home) && !xdg_config_home.IsEmpty()) {
+        file_name = wxFileName(xdg_config_home, wxEmptyString);
+    } else {
+        file_name = wxFileName(wxGetHomeDir(), wxEmptyString);
+        file_name.AppendDir(".config");
+    }
 #endif
     file_name.AppendDir(app_name);
     file_name.Mkdir(0755, wxPATH_MKDIR_FULL);


### PR DESCRIPTION
Spek creates `~/.config/spek/` on startup, and does not respect the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) correctly:

> `XDG_CONFIG_HOME` defines the base directory relative to which user-specific configuration files should be stored. If `$XDG_CONFIG_HOME` is either not set or empty, a default equal to `$HOME/.config` should be used.

Even if the environment variable is configured, it's not considered, and the default location is used anyway. This fixes that.