### PR TITLE
update Homebrew build dependencies

### DIFF
--- a/dist/osx/README.md
+++ b/dist/osx/README.md
@@ -2,9 +2,8 @@
 
 Using [Homebrew](http://brew.sh) install build dependencies:
 
-    brew install autoconf automake coreutils git libtool pkg-config
-    brew install ffmpeg gettext wxmac
-    brew link --force gettext
+    brew install automake coreutils git
+    brew install ffmpeg wxwidgets
 
 Bundle Spek:
 


### PR DESCRIPTION
I have successfully built v0.8.5 on my Intel MacBook with macOS Mojave 10.14.6.
https://github.com/samuello1228/spek-my-build/tree/main/v0.8.5

autoconf is the dependency of automake.
libtool, pkg-config and gettext are the build dependencies of ffmpeg.
They will be automatically installed by Homebrew.

wxmac was renamed to wxwidgets.

gettext should be automatically linked.