### PR TITLE
Add a NEWS file for tracking major changes across versions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,154 @@
+Version 0.8.5
+~~~~~~~~~~~~~~~~~~~~
+Released: 2023-01-09
+
+Features:
+* Upgrade to FFmpeg 5.1
+
+Miscellaneous:
+* Use XDG_CONFIG_HOME on Unix systems.
+
+Version 0.8.4
+~~~~~~~~~~~~~~~~~~~~
+Released: 2022-07-10
+
+Features:
+* Add 2 more palettes and change the default.
+* Allow changing the DFT window size and function.
+* Allow switching between audio streams and channels.
+* Add translations for 14 additional languages.
+
+Miscellaneous:
+* Remove dependency on intltool.
+* Fix FFmpeg build warnings.
+* Detect AR tool.
+* Use Homebrew for macOS dependencies.
+* Improve test coverage.
+
+Bugfixes:
+* Remove association with .mod and MIDI files.
+* Fix autoconf errors.
+* Fix an AVX-related crash.
+
+Version 0.8.3
+~~~~~~~~~~~~~~~~~~~~
+Released: 2013-02-26
+
+Bugfixes:
+* OS X specific bugfix release
+
+Version 0.8.2
+~~~~~~~~~~~~~~~~~~~~
+Released: 2013-02-24
+
+Features:
+* Open .opus audio files (#39).
+
+Miscellaneous:
+* Use non-deprecated FFmpeg decoding API.
+* Moved downloads to Google Code since GitHub no longer offers downloads (#38).
+* Compatibility with retina-based Macs (#32).
+
+Bugfixes:
+* Fix magnitude calculation for the first and the last frequency band.
+* Support planar sample formats (#44).
+
+Version 0.8.1
+~~~~~~~~~~~~~~~~~~~~
+Released: 2012-09-27
+
+Bugfixes:
+* Fixed mapping of the spectral density into the palette.
+
+Version 0.8.0
+~~~~~~~~~~~~~~~~~~~~
+Released: 2012-09-23
+
+Features:
+* Adjustable spectral density range (#4).
+* Switched from GTK+ to wxWidgets for better Windows and OS X integration.
+* Single .exe version for Windows.
+* Added translations in 8 more languages (totalling 16).
+
+Miscellaneous:
+* Switched to .xz tarballs.
+* Split out libspek and added unit tests.
+* 24-bit APE support (upstream fix).
+* Better toolbar icons on Windows and OS X (#21).
+* Installer options for app shortcuts on Windows (#1).
+* Associate with audio/video files on OS X (#2).
+* Online manual (#24).
+
+Bugfixes:
+* Fixed crash when the preferences file is not writable.
+* Fixed crash when the home directory is not writable.
+* Fixed duration and rendering for some video files.
+* Fixed compilation with newer FFmpeg and libav versions.
+* Proper handling of Unicode file names under Windows (upstream fix).
+* Don't lock the input file on Windows (#26).
+
+Version 0.7
+~~~~~~~~~~~~~~~~~~~~
+Released: 2011-04-24
+
+Features:
+* Added translations in 8 languages
+* Preferences to select a language and to check for a new version
+* Spectral density ruler
+* Added a menu bar, cleaned up the tool bar.
+* Better OS X integration
+
+Miscellaneous:
+ * Show the version number in the window
+ * Pre-compute the cosine table to speed up analysis by ±16%
+ * Use jhbuild and ige-mac-bundler to build and package Spek on OS X
+ * spek(1) man page
+ * Avoid using APIs depreciated in GTK3
+
+Bugfixes:
+* Fixed link activation on OS X (issue 31)
+* Fixed new version detection on OS X
+* Fixed duration for unsynchronised ID3v24 mp3 tags (upstream fix)
+* Fixed rigth click → Quit (issue 24) and the ⌘ Q shortcut (issue 44)
+
+Version 0.6
+~~~~~~~~~~~~~~~~~~~~
+Released: 2010-07-13
+
+Features:
+* Switch from GStreamer to FFmpeg libraries for audio decoding. This speeds up the overall analysis by a factor of 1.5 to 2.
+* Decode audio and perform the analysis in separate threads. This makes the analysis 1.3~1.8 times faster on multi-core systems (issue 11).
+* Check for a new version once a week and notify when it becomes available (issue 27)
+
+Miscellaneous:
+* Windows installer branding (issue 32)
+* Option to launch Spek when the Windows installer exits
+
+Bugfixes:
+* Fix link activation on Windows (issue 31)
+* Fix ALAC issues on OS X (issue 23)
+* Re-run the analysis only if the window width has been changed
+* Fix opening of files containing Unicode symbols in their name on Windows
+
+Version 0.5
+~~~~~~~~~~~~~~~~~~~~
+Released: 2010-06-25
+
+Features:
+* Speed up spectral analysis by using the optimal number of frequency bands.
+* DTS files support.
+* Distribute Windows version as a ZIP archive in addition to the MSI installer.
+* Mac OS X installer.
+* Use Pango to render text.
+* Brand new icon.
+
+Version 0.4
+~~~~~~~~~~~~~~~~~~~~
+Released: 2010-05-21
+
+Features:
+* Associate with audio files ("Open with..." menu in file managers)
+* Show the name of the open file in the window title
+* Support 24-bit FLACs
+* Drag and Drop support
+* Show file name and its properties in the window


### PR DESCRIPTION
NEWS files commonly used for storing changes in a human-readable format, and can be combined with AppStream metainfo files.