### PR TITLE
Fix Blackman-Harris window cosine period

### DIFF
--- a/src/spek-pipeline.cc
+++ b/src/spek-pipeline.cc
@@ -373,7 +373,11 @@ static float get_window(enum window_function f, int i, float *coss, int n) {
     case WINDOW_HAMMING:
         return 0.53836f - 0.46164f * coss[i];
     case WINDOW_BLACKMAN_HARRIS:
-        return 0.35875f - 0.48829f * coss[i] + 0.14128f * coss[2*i % n] - 0.01168f * coss[3*i % n];
+        {
+            int period = n - 1;
+            return 0.35875f - 0.48829f * coss[i] + 0.14128f * coss[2*i % period] -
+                0.01168f * coss[3*i % period];
+        }
     default:
         assert(false);
         return 0.0f;


### PR DESCRIPTION
## Summary

Fixes the Blackman-Harris window formula used in the spectrogram pipeline by using `N - 1` as the cosine period denominator instead of `N`.

## Details

The Blackman-Harris window is defined over a symmetric interval where the cosine terms use `2*pi*n/(N - 1)`. Using `N` slightly distorts the window coefficients, especially near the endpoints, and makes the implementation diverge from the standard definition.

This change updates the period calculation while leaving the rest of the windowing logic unchanged.

## Testing

Built/tested locally.